### PR TITLE
feat: add old-form partial continuous aggregate count

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -112,7 +112,10 @@ QUERIES = [
     }, {
         "name": "Num TimescaleDB Continuous Aggregates",
         "query": "select count(*) from timescaledb_information.continuous_aggregates",
-    },  {
+    }, {
+        "name": "Num old partial-form Continuous Aggregates",
+        "query": "select count(*) from timescaledb_information.continuous_aggregates where not finalized",
+    }, {
         "name": "Num TimescaleDB space dimensions",
         "query": "select count(*) from timescaledb_information.dimensions where dimension_type = 'Space'",
     }, {


### PR DESCRIPTION
Partial-form continuous aggregates will cause issues when migrated across pg versions:
 - https://github.com/timescale/timescaledb/issues/4403
 - https://github.com/timescale/timescaledb/issues/4937.

Partial-form continuous aggregates must be [migrated] to the finalized form in the source database, before a migration can be carried out.

[migrated]: https://docs.timescale.com/use-timescale/latest/continuous-aggregates/migrate/