### PR TITLE
feat: add db schemas and pgstattuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Num tables: 74
 Num regular PostgreSQL tables excl. Hypertables: 8
 Num declarative partitions: 2
 Non-standard tablespaces: -
-Databases: {_timescaledb,defaultdb,tsbs}
+Current database: tsbs
+Other databases: {_timescaledb,defaultdb}
+Schemas: {public,iot}
 TimescaleDB version: 2.13.1
 Num TimescaleDB Hypertables: 2
 Num TimescaleDB Continuous Aggregates: 1

--- a/evaluate.py
+++ b/evaluate.py
@@ -114,7 +114,8 @@ QUERIES = [
             where
                 schema_name not in ('pg_catalog', 'information_schema', '_timescaledb_functions',
                 'timescaledb_experimental', '_timescaledb_cache', '_timescaledb_catalog',
-                '_timescaledb_config', '_timescaledb_internal', 'timescaledb_information')
+                '_timescaledb_config', '_timescaledb_internal', 'timescaledb_information',
+                'toolkit_experimental')
             """
     }, {
         "name": "TimescaleDB version",

--- a/evaluate.py
+++ b/evaluate.py
@@ -45,6 +45,7 @@ SUPPORTED_EXTENSIONS = [
     "pgcrypto",
     "pgpcre",
     "pgrouting",
+    "pgstattuple",
     "pgvector",
     "plpgsql",
     "postgis",
@@ -106,6 +107,15 @@ QUERIES = [
     }, {
         "name": "Other databases",
         "query": "select array_agg(datname) from pg_database where datname not in ('template0', 'template1', 'rdsadmin', 'tsadmin', current_database())",
+    }, {
+        "name": "Schemas",
+        "query": """
+            select array_agg(schema_name) from information_schema.schemata
+            where
+                schema_name not in ('pg_catalog', 'information_schema', '_timescaledb_functions',
+                'timescaledb_experimental', '_timescaledb_cache', '_timescaledb_catalog',
+                '_timescaledb_config', '_timescaledb_internal', 'timescaledb_information')
+            """
     }, {
         "name": "TimescaleDB version",
         "query": "select extversion from pg_extension where extname = 'timescaledb'",


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

This commit:
- adds a new metric that shows an array agg of non-default schemas including 'public'.
- add 'pgstattuple' as list of supported extensions on cloud. Note: This is unavailable on the webpage of supported extensions but works when installed with 'CREATE EXTENSION' on cloud.