### PR TITLE
chore: add python version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository provides scripts that assist the Timescale migration team
 in selecting the optimal migration strategy to Timescale Cloud for your
 specific database.
 
-You will need `Python 3.x` and `psql` to run the scripts.
+You will need `Python 3.7.x` or above and `psql` to run the scripts.
 
 To recommend a suitable migration strategy for your database, we'll need
 some information about its current state. You can collect this information


### PR DESCRIPTION
Python 3.6 leads to error in following line

```python
result = subprocess.run(cmd, text=True, stdout=subprocess.PIPE)
```

Error
```shell
TypeError: __init__() got an unexpected keyword argument 'text'
```

The script works fine with python `v3.7.0`.